### PR TITLE
Fixes build and closes #2

### DIFF
--- a/machines-directory.cabal
+++ b/machines-directory.cabal
@@ -14,14 +14,14 @@ library
   default-language:  Haskell2010
   hs-source-dirs:    src
   ghc-options:       -fwarn-incomplete-patterns
-  exposed-modules: 
+  exposed-modules:
     System.Directory.Machine
     System.Directory.Machine.Internal
-  build-depends:       
+  build-depends:
       base                >= 4.6      && < 5
     , directory           >= 1.2      && < 1.3
     , filepath            >= 1.3      && < 1.4
     , transformers        >= 0.3      && < 0.5
-    , machines            >= 0.2      && < 0.3
+    , machines            >= 0.2.4    && < 0.3
     , machines-io         >= 0.1      && < 0.2
 


### PR DESCRIPTION
Builds were failing due to the use of the `autoM` function from
`Data.Machine`. This function is from `Data.Machine.Process` and is only
exported on `machines >=0.2.4`. This changes the lower bound of the
`machines` dependency to reflect that and fixes the build. It closes the
issue #2 and should also close issue aloiscochard/codex#24 only
published and used there.

For reference:
- [`Data.Machine.Process@0.2.3.1`](http://hackage.haskell.org/package/machines-0.2.3.1/docs/src/Data-Machine-Process.html)
- [`Data.Machine.Process@0.2.4`](http://hackage.haskell.org/package/machines-0.2.4/docs/src/Data-Machine-Process.html)
