### PR TITLE
Relax directory upper bound

### DIFF
--- a/machines-directory.cabal
+++ b/machines-directory.cabal
@@ -19,7 +19,7 @@ library
     System.Directory.Machine.Internal
   build-depends:
       base                >= 4.6      && < 5
-    , directory           >= 1.2      && < 1.3
+    , directory           >= 1.2      && < 1.4
     , filepath            >= 1.3      && < 1.5
     , transformers        >= 0.3      && < 0.6
     , machines            >= 0.2.4    && < 0.7


### PR DESCRIPTION
Breaking changes in `directory-1.3` are related to `canonicalizePath` which isn't used in this package. http://hackage.haskell.org/package/directory-1.3.0.0/changelog